### PR TITLE
Introduce URXVT_TAB environment variable

### DIFF
--- a/tabbedex
+++ b/tabbedex
@@ -470,8 +470,11 @@ sub new_tab {
 
    push @urxvt::TERM_EXT, urxvt::ext::tabbedex::tab::;
 
+   my %env = %{ $self->env };
+   $env{'URXVT_TAB'} = sprintf '%d:', $self->{tabs_open_so_far};
+
    my $term = new urxvt::term
-      $self->env, $urxvt::RXVTNAME,
+      \%env, $urxvt::RXVTNAME,
       -embed => $self->parent,
       @{ $self->{argv} };
 }
@@ -719,6 +722,8 @@ sub on_init {
    my @blacklist = split(',', $self->rs_text ('perl-ext-blacklist'));
    $self->{perl_ext_blacklist} = join (',-', ',-tabbedex', @blacklist);
 
+   $self->{tabs_open_so_far} = 0;
+
    ();
 }
 
@@ -802,6 +807,8 @@ sub tab_start {
 
 #   $tab->{name} ||= scalar @{ $self->{tabs} };
    $self->make_current ($tab);
+
+   ++$self->{tabs_open_so_far};
 
    ();
 }


### PR DESCRIPTION
Process in each tab will now have a URXVT_TAB variable set in their
environment.  It’s value is a total number of tabs opened by urxvt
followed by a colon.  The number starts at zero and always increases.

The colon is intended for future extension as more information may be
passed over time in the variable.

This feature can be used to provide per-tab initialisation or command.
For example, ~/.bashrc could include:

    if [ -n "$URXVT_TAB" ]; then
        tab=$URXVT_TAB
        unset URXVT_TAB

        set_urxvt_tab_name() {
            printf '\033]777;tabbedx;set_tab_name;%s\007' "$1"
        }

        case "$tab" in
        0:*)
            set_urxvt_tab_name emacs
            exec emacs
            ;;
        1:*)
            set_urxvt_tab_name work
            ;;
        2:*)
            set_urxvt_tab_name nethack
            exec nethack
            ;;
        esac
    fi

to name the first three tabs ‘emacs’, ‘work’ and ‘nethack’ and start
Emacs and NetHack in their respective tabs.